### PR TITLE
New feature get_optional to render optional arguments in SQL template.

### DIFF
--- a/Products/ZAlchemyConnector/SQLTemplate.py
+++ b/Products/ZAlchemyConnector/SQLTemplate.py
@@ -129,6 +129,18 @@ class SQLTemplate(SimpleItem.SimpleItem, Folder):
         """Return args' value from list of args."""
         return self.args.get(arg)['value']
 
+    def get_optional(self, arg):
+        """Try to get value of optional argument.
+
+        If arg exists and has value, returns arg formatted for biding.
+        If arg not exists or has no value, returns NULL.
+        """
+        arg_val = self.args.get(arg, {}).get('value', None)
+        if arg_val:
+            return """:{}""".format(arg)
+
+        return """NULL"""
+
     def check(self, arg):
         """Check arg.
 


### PR DESCRIPTION
Added a new method to render optional arguments in SQL template. This way, simply call method "get_optional" from template  by passing the argument var name and if argument exists and value is anything but None it will return a formatted string ready for biding like this => ":$var" , if not, renders NULL.